### PR TITLE
Refactor: Change grades data type from u32 to f32

### DIFF
--- a/02-intermediate-rust/01_structs/structs_05/src/main.rs
+++ b/02-intermediate-rust/01_structs/structs_05/src/main.rs
@@ -3,18 +3,17 @@
 struct Student {
     name: String,
     age: u8,
-    grades: Vec<u32>
+    grades: Vec<f32>
 }
 
 impl Student {
-    fn get_avg_grades(&self) -> u32 {
-        let mut sum: u32 = 0;
-        let len: u32 = self.grades.len() as u32;
+    fn get_avg_grades(&self) -> f32 {
+        let mut sum: f32 = 0.0;
+        let len = self.grades.len() as f32;
 
         for grade in &self.grades {
-            sum += grade;
+            sum += grade;        
         }
-
         sum / len
     }
 }
@@ -23,9 +22,12 @@ fn main() {
     let student: Student = Student {
         name: "Kamlesh".to_string(),
         age: 13,
-        grades: vec![45, 56, 78, 32, 99]
+        grades: vec![45.0, 56.5, 78.6, 32.6, 100.0]
     };
 
-    let avg_grade: u32 = student.get_avg_grades();
+    let avg_grade: f32 = student.get_avg_grades();
     println!("Average grade of {:?} of age {} is {}.", student.name, student.age, avg_grade);
 }
+
+
+


### PR DESCRIPTION
**Summary:** This pull request changes the data type for grades from `u32` to `f32` to allow for greater precision, particularly when working with fractional grade values.

**Reason for the Change:** The current implementation uses `u32` for grades, which restricts precision to whole numbers. To support fractional grades and improve accuracy in calculations, `f32` is more appropriate.

**Changes Made:**

Updated the grades field from `u32` to `f32` in:
    `src/main.rs`

Adjusted all related calculations and logic to handle `f32`.